### PR TITLE
Use trial end date from `trial_end_pre_cancellation` meta for subscriptions pending cancellation.

### DIFF
--- a/src/SubscriptionUpdater.php
+++ b/src/SubscriptionUpdater.php
@@ -102,7 +102,13 @@ class SubscriptionUpdater {
 		$trial_period = $woocommerce_subscription->get_trial_period();
 
 		if ( '' !== $trial_period ) {
-			$trial_end_date = new \DateTimeImmutable( $woocommerce_subscription->get_date( 'trial_end', 'gmt' ), new \DateTimeZone( 'GMT' ) );
+			$trial_end = $woocommerce_subscription->get_date( 'trial_end', 'gmt' );
+
+			if ( empty( $trial_end ) && $woocommerce_subscription->meta_exists( 'trial_end_pre_cancellation' ) ) {
+				$trial_end = $woocommerce_subscription->get_meta( 'trial_end_pre_cancellation' );
+			}
+
+			$trial_end_date = new \DateTimeImmutable( $trial_end, new \DateTimeZone( 'GMT' ) );
 
 			$interval_start_date = $start_date->setTime( $start_date->format( 'H' ), $start_date->format( 'i' ) );
 			$interval_end_date   = $trial_end_date->setTime( $trial_end_date->format( 'H' ), $trial_end_date->format( 'i' ) );


### PR DESCRIPTION
When a WooCommerce subscription is marked for cancellation (either by the user through the account or an admin manually changing the subscription status to 'Pending cancellation'), WooCommerce Subscriptions updates the trial end date meta to `0` and moves the current trial end date value to the `trial_end_pre_cancellation` meta:

https://github.com/pronamic/woocommerce-subscriptions/blob/50b02db3314ce937e9a670b4215fa4cced7652cf/vendor/woocommerce/subscriptions-core/includes/class-wc-subscription.php#L444-L468

This PR resolves the fatal error from issue #14 in the subscription updater by using the trial end date from `trial_end_pre_cancellation` meta if the `trial_end` meta is empty.