### PR TITLE
Fix undefined function error

### DIFF
--- a/src/SubscriptionUpdater.php
+++ b/src/SubscriptionUpdater.php
@@ -187,6 +187,10 @@ class SubscriptionUpdater {
 	 * @return void
 	 */
 	public static function maybe_update_pronamic_subscription( $post_id ) {
+		if ( ! function_exists( 'wcs_get_subscription' ) ) {
+		    return;
+		}
+
 		// Get WooCommerce subscription.
 		$woocommerce_subscription = \wcs_get_subscription( $post_id );
 


### PR DESCRIPTION
PR that fixes the following undefined function error:

```
 Fatal error: Uncaught Error: Call to undefined function wcs_get_subscription()
in /Users/jeffreyvanrossum/Sites/eisma/wp-content/plugins/pronamic-ideal/vendor/wp-pay-extensions/woocommerce/src/SubscriptionUpdater.php on line 195
```

Gets triggered by:
https://github.com/pronamic/wp-pronamic-pay-woocommerce/blob/develop/src/Extension.php#L94

This results in a fatal error on `wp-admin/post-new.php`.