### PR TITLE
Only set order status to pending payment if order still needs payment…

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -694,9 +694,15 @@ class Extension extends AbstractPluginIntegration {
 		}
 
 		/**
-		 * Pending payment.
+		 * For new WooCommerce orders, the order status is 'pending' by
+		 * default. It is possible that a first payment attempt fails and the
+		 * order status is set to 'failed'. If a new payment attempt is made,
+		 * we will reset the order status to pending payment.
+		 * 
+		 * @link https://github.com/woocommerce/woocommerce/blob/7897a61a1040ca6ed3310cb537ce22211058256c/plugins/woocommerce/includes/abstracts/abstract-wc-order.php#L402-L403
+		 * @link https://github.com/pronamic/wp-pronamic-pay-woocommerce/issues/48
 		 */
-		if ( PaymentStatus::OPEN === $payment->get_status() ) {
+		if ( PaymentStatus::OPEN === $payment->get_status() && $order->needs_payment() && 'pending' !== $order->get_status() ) {
 			$new_status = WooCommerce::ORDER_STATUS_PENDING;
 		}
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -655,6 +655,15 @@ class Extension extends AbstractPluginIntegration {
 			return;
 		}
 
+		/**
+		 * This status update function will not update WooCommerce subscription orders.
+		 * 
+		 * @link https://github.com/pronamic/wp-pronamic-pay-woocommerce/issues/48
+		 */
+		if ( 'shop_subscription' === $order->get_type() ) {
+			return;
+		}
+
 		$new_status = null;
 
 		/**

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -447,22 +447,6 @@ class Gateway extends WC_Payment_Gateway {
 
 		$order->save();
 
-		// Reload order for actual status (could be paid already; i.e. through recurring credit card payment).
-		$order = \wc_get_order( $order );
-
-		/**
-		 * For new WooCommerce orders, the order status is 'pending' by
-		 * default. It is possible that a first payment attempt fails and the
-		 * order status is set to 'failed'. If a new payment attempt is made,
-		 * we will reset the order status to pending payment.
-		 * 
-		 * @link https://github.com/woocommerce/woocommerce/blob/7897a61a1040ca6ed3310cb537ce22211058256c/plugins/woocommerce/includes/abstracts/abstract-wc-order.php#L402-L403
-		 * @link https://github.com/pronamic/wp-pronamic-pay-woocommerce/issues/48
-		 */
-		if ( $order->needs_payment() && 'pending' !== $order->get_status() ) {
-			$order->update_status( 'pending', \__( 'Awaiting payment.', 'pronamic_ideal' ) );
-		}
-
 		// Return results array.
 		return [
 			'result'   => 'success',

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -450,18 +450,17 @@ class Gateway extends WC_Payment_Gateway {
 		// Reload order for actual status (could be paid already; i.e. through recurring credit card payment).
 		$order = \wc_get_order( $order );
 
-		// Order note and status.
-		$new_status_slug = WooCommerce::ORDER_STATUS_PENDING;
-
-		$note = __( 'Awaiting payment.', 'pronamic_ideal' );
-
-		$order_status = WooCommerce::order_get_status( $order );
-
-		// Only add order note if status is already pending or if WooCommerce Deposits is activated.
-		if ( $new_status_slug === $order_status || isset( $order->wc_deposits_remaining ) ) {
-			$order->add_order_note( $note );
-		} elseif ( PaymentStatus::SUCCESS !== $payment->get_status() ) {
-			$order->update_status( $new_status_slug, $note );
+		/**
+		 * For new WooCommerce orders, the order status is 'pending' by
+		 * default. It is possible that a first payment attempt fails and the
+		 * order status is set to 'failed'. If a new payment attempt is made,
+		 * we will reset the order status to pending payment.
+		 * 
+		 * @link https://github.com/woocommerce/woocommerce/blob/7897a61a1040ca6ed3310cb537ce22211058256c/plugins/woocommerce/includes/abstracts/abstract-wc-order.php#L402-L403
+		 * @link https://github.com/pronamic/wp-pronamic-pay-woocommerce/issues/48
+		 */
+		if ( $order->needs_payment() && 'pending' !== $order->get_status() ) {
+			$order->update_status( 'pending', \__( 'Awaiting payment.', 'pronamic_ideal' ) );
 		}
 
 		// Return results array.


### PR DESCRIPTION
Only set order status to pending payment if order still needs payment and order status is not already pending.

A WooCommerce Subscription change payment method action should now result in the following exception/error:

``` 
Fatal error: Uncaught Exception: Unprocessable Entity - The amount is lower than the minimum
```

This is something else, we should create a new issue for that, for now awaiting review from @rvdsteege.
