### PR TITLE
No longer wrap notice in <div> element

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -517,11 +517,7 @@ class Extension extends AbstractPluginIntegration {
 		}
 
 		// Add notice.
-		$message .= \sprintf(
-			'<div class="woocommerce-info">%s</div>',
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			__( 'We process your order as soon as we have processed your payment.', 'pronamic_ideal' )
-		);
+		$message .= ' ' . \__( 'We process your order as soon as we have processed your payment.', 'pronamic_ideal' );
 
 		return $message;
 	}


### PR DESCRIPTION
<img width="1066" alt="Scherm­afbeelding 2023-09-15 om 15 55 46" src="https://github.com/pronamic/wp-pronamic-pay-woocommerce/assets/869674/8dff7984-8040-4d39-af8a-d0410e2f14ef">
