### PR TITLE
Add Pronamic Pay meta box to WooCommerce admin order page

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -129,6 +129,36 @@ class Extension extends AbstractPluginIntegration {
 		add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'checkout_fields' ], 10, 1 );
 		add_action( 'woocommerce_checkout_update_order_meta', [ __CLASS__, 'checkout_update_order_meta' ], 10, 2 );
 
+		if ( \is_admin() ) {
+			\add_action(
+				'add_meta_boxes',
+				function( $post_type, $post ) {
+					if ( 'shop_order' !== $post_type ) {
+						return;
+					}
+
+					$order = \wc_get_order();
+
+					if ( ! $order instanceof WC_Order ) {
+						return;
+					}
+
+					\add_meta_box(
+						'woocommerce-order-pronamic-pay',
+						\__( 'Pronamic Pay', 'pronamic_ideal' ),
+						function( $post ) use ( $order ) {
+							include __DIR__ . '/../views/admin-meta-box-woocommerce-order.php';
+						},
+						$post_type,
+						'side',
+						'default'
+					);
+				},
+				10,
+				2
+			);
+		}
+
 		self::register_settings();
 	}
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -22,6 +22,7 @@ use Pronamic\WordPress\Pay\Util as Pay_Util;
 use WC_Order;
 use WC_Order_Item;
 use WC_Payment_Gateway;
+use WP_Post;
 
 /**
  * Title: WooCommerce iDEAL Add-On
@@ -130,33 +131,7 @@ class Extension extends AbstractPluginIntegration {
 		add_action( 'woocommerce_checkout_update_order_meta', [ __CLASS__, 'checkout_update_order_meta' ], 10, 2 );
 
 		if ( \is_admin() ) {
-			\add_action(
-				'add_meta_boxes',
-				function( $post_type, $post ) {
-					if ( 'shop_order' !== $post_type ) {
-						return;
-					}
-
-					$order = \wc_get_order();
-
-					if ( ! $order instanceof WC_Order ) {
-						return;
-					}
-
-					\add_meta_box(
-						'woocommerce-order-pronamic-pay',
-						\__( 'Pronamic Pay', 'pronamic_ideal' ),
-						function( $post ) use ( $order ) {
-							include __DIR__ . '/../views/admin-meta-box-woocommerce-order.php';
-						},
-						$post_type,
-						'side',
-						'default'
-					);
-				},
-				10,
-				2
-			);
+			\add_action( 'add_meta_boxes', [ __CLASS__, 'maybe_add_pronamic_pay_meta_box_to_wc_order' ], 10, 2 );
 		}
 
 		self::register_settings();
@@ -1349,5 +1324,37 @@ class Extension extends AbstractPluginIntegration {
 		 * @link https://github.com/pronamic/wp-pronamic-pay-mollie/issues/18#issuecomment-1373362874
 		 */
 		\do_action( 'pronamic_pay_payment_fulfilled', $payment );
+	}
+
+	/**
+	 * Maybe add a Pronamic Pay meta box the WooCommerce order.
+	 * 
+	 * @link https://github.com/pronamic/wp-pronamic-pay-woocommerce/issues/41
+	 * @link https://developer.wordpress.org/reference/hooks/add_meta_boxes/
+	 * @param string  $post_type Post type.
+	 * @param WP_Post $post      Post object.
+	 * @return void
+	 */
+	public static function maybe_add_pronamic_pay_meta_box_to_wc_order( $post_type, $post ) {
+		if ( 'shop_order' !== $post_type ) {
+			return;
+		}
+
+		$order = \wc_get_order();
+
+		if ( ! $order instanceof WC_Order ) {
+			return;
+		}
+
+		\add_meta_box(
+			'woocommerce-order-pronamic-pay',
+			\__( 'Pronamic Pay', 'pronamic_ideal' ),
+			function( $post ) use ( $order ) {
+				include __DIR__ . '/../views/admin-meta-box-woocommerce-order.php';
+			},
+			$post_type,
+			'side',
+			'default'
+		);
 	}
 }

--- a/views/admin-meta-box-woocommerce-order.php
+++ b/views/admin-meta-box-woocommerce-order.php
@@ -58,6 +58,14 @@ $payment = get_pronamic_payment( $payment_id );
 			</tr>
 			<tr>
 				<th scope="row">
+					<?php esc_html_e( 'Status', 'pronamic_ideal' ); ?>
+				</th>
+				<td>
+					<?php echo esc_html( $payment->get_status_label() ); ?>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
 					<?php esc_html_e( 'Transaction ID', 'pronamic_ideal' ); ?>
 				</th>
 				<td>

--- a/views/admin-meta-box-woocommerce-order.php
+++ b/views/admin-meta-box-woocommerce-order.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * WordPress admin meta box WooCommercer order Pronamic Pay
+ *
+ * @author    Pronamic <info@pronamic.eu>
+ * @copyright 2005-2023 Pronamic
+ * @license   GPL-3.0-or-later
+ * @package   Pronamic\WordPress\Pay
+ */
+
+$payment_id = (int) $order->get_meta( '_pronamic_payment_id' );
+
+$payment = get_pronamic_payment( $payment_id );
+
+?>
+<style>
+	#woocommerce-order-pronamic-pay .inside {
+		margin: 0;
+		padding: 10px;
+	}
+
+	#woocommerce-order-pronamic-pay th {
+		text-align: left;
+	}
+</style>
+
+<?php if ( null === $payment ) : ?>
+
+	<?php esc_html_e( 'No Pronamic Pay payment found for this WooCommerce order.', 'pronamic_ideal' ); ?>
+
+<?php else : ?>
+
+	<table>
+		<tbody>
+			<tr>
+				<th scope="row">
+					<?php esc_html_e( 'ID' ); ?>
+				</th>
+				<td>
+					<?php edit_post_link( $payment->get_id(), '', '', $payment->get_id() ); ?>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<?php esc_html_e( 'Date', 'pronamic_ideal' ); ?>
+				</th>
+				<td>
+					<?php echo esc_html( $payment->date->format_i18n() ); ?>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<?php esc_html_e( 'Amount', 'pronamic_ideal' ); ?>
+				</th>
+				<td>
+					<?php echo esc_html( $payment->get_total_amount()->format_i18n() ); ?>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<?php esc_html_e( 'Transaction ID', 'pronamic_ideal' ); ?>
+				</th>
+				<td>
+					<?php
+
+					$transaction_id = (string) $payment->get_transaction_id();
+
+					$url = (string) $payment->get_provider_link();
+
+					if ( '' === $url ) {
+						echo esc_html( $transaction_id );
+					}
+
+					if ( '' !== $url ) {
+						printf(
+							'<a href="%s">%s</a>',
+							esc_url( $url ),
+							esc_html( $transaction_id )
+						);
+					}
+
+					?>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+
+<?php endif; ?>


### PR DESCRIPTION
<img width="304" alt="Scherm­afbeelding 2023-09-18 om 15 56 25" src="https://github.com/pronamic/wp-pronamic-pay-woocommerce/assets/869674/9909dd8c-ed90-495c-bf55-54b0bf4c6754">
