### PR TITLE
Set order status on hold when processing scheduled subscription payment.

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -902,6 +902,8 @@ class Gateway extends WC_Payment_Gateway {
 
 		Plugin::start_payment( $payment );
 
+		$order->set_status( WooCommerce::ORDER_STATUS_ON_HOLD );
+
 		$this->store_payment_details( $order, $payment );
 	}
 


### PR DESCRIPTION
I've tested if we could just simply set the order status to "On Hold" in `$gateway->process_subscription_payment()` to resolve #70. This seemed to work fine:

- orders are put on hold when renewed by WooCommerce (through action `woocommerce_scheduled_subscription_payment_{gateway_id}`)
- starting a payment through "**Renew now**" in the customer account will not put the order on hold (uncompleted payments will therefore not result in payment interruptions for the subscription)
- starting a payment through "**Change payment**" in the customer account will not put the order on hold (uncompleted payments will therefore not result in payment interruptions for the subscription)