### PR TITLE
Set meta `woocommerce_subscription_change_payment_method` on payment method changes for use in payment status updates

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -541,6 +541,8 @@ class Gateway extends WC_Payment_Gateway {
 		if ( \did_action( 'woocommerce_subscription_change_payment_method_via_pay_shortcode' ) ) {
 			$payment->set_meta( 'mollie_sequence_type', 'first' );
 
+			$payment->set_meta( 'woocommerce_subscription_change_payment_method', true );
+
 			/**
 			 * Use payment method minimum amount for verification payment.
 			 *


### PR DESCRIPTION
Together with PR https://github.com/pronamic/wp-pay-core/pull/213, this fixes https://github.com/pronamic/pronamic.shop/issues/56.