### PR TITLE
Make sure we retrieve the subscriptions from all order types

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -840,7 +840,7 @@ class Gateway extends WC_Payment_Gateway {
 			return $pronamic_subscriptions;
 		}
 
-		$woocommerce_subscriptions = \wcs_get_subscriptions_for_order( $order );
+		$woocommerce_subscriptions = \wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] );
 
 		foreach ( $woocommerce_subscriptions as $woocommerce_subscription ) {
 			$pronamic_subscription = new Subscription();


### PR DESCRIPTION
See https://github.com/pronamic/wp-pronamic-pay-woocommerce/issues/79 for details.