### PR TITLE
Use "Direct Debit" payment method title in customer context for subscriptions using iDEAL and Bancontact

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -90,6 +90,8 @@ class Extension extends AbstractPluginIntegration {
 
 		add_filter( 'woocommerce_thankyou_order_received_text', self::woocommerce_thankyou_order_received_text( ... ), 20, 2 );
 
+		\add_filter( 'woocommerce_order_get_payment_method_title', self::order_payment_method_title( ... ), 10, 2 );
+
 		\add_action( 'before_woocommerce_pay', $this->maybe_add_failure_reason_notice( ... ) );
 
 		\add_action( 'pronamic_pay_update_payment', $this->maybe_update_refunded_payment( ... ), 15, 1 );
@@ -291,6 +293,40 @@ class Extension extends AbstractPluginIntegration {
 		$message .= ' ' . \__( 'We process your order as soon as we have processed your payment.', 'pronamic-pay-woocommerce' );
 
 		return $message;
+	}
+
+	/**
+	 * Filter WooCommerce order payment method title.
+	 *
+	 * @param string    $payment_method_title Payment method title.
+	 * @param \WC_Order $order                WooCommerce order.
+	 *
+	 * @return string
+	 */
+	public static function order_payment_method_title( $payment_method_title, $order ) {
+		if ( ! function_exists( '\wcs_order_contains_renewal' ) || ! \wcs_order_contains_renewal( $order )) {
+			return $payment_method_title;
+		}
+
+		$payment_gateway = \wc_get_payment_gateway_by_order( $order );
+
+		if ( false === $payment_gateway ) {
+			return $payment_method_title;
+		}
+
+		// Check if Pronamic Pay gateway.
+		if ( ! \method_exists( $payment_gateway, 'get_wp_payment_method' ) ) {
+			return $payment_method_title;
+		}
+
+		if ( \is_account_page() && $order->needs_payment() ) {
+			return $payment_method_title;
+		}
+
+		return match ( $payment_gateway->get_wp_payment_method() ) {
+			PaymentMethods::IDEAL, PaymentMethods::BANCONTACT => PaymentMethods::get_name( PaymentMethods::DIRECT_DEBIT ),
+			default => $payment_method_title,
+		};
 	}
 
 	/**

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -311,12 +311,7 @@ class Extension extends AbstractPluginIntegration {
 
 		$payment_gateway = \wc_get_payment_gateway_by_order( $order );
 
-		if ( false === $payment_gateway ) {
-			return $payment_method_title;
-		}
-
-		// Check if Pronamic Pay gateway.
-		if ( ! \method_exists( $payment_gateway, 'get_wp_payment_method' ) ) {
+		if ( ! $payment_gateway instanceof Gateway ) {
 			return $payment_method_title;
 		}
 
@@ -346,12 +341,8 @@ class Extension extends AbstractPluginIntegration {
 
 		$payment_gateway = \wc_get_payment_gateway_by_order( $order );
 
-		if ( false === $payment_gateway ) {
-			return $payment_method_title;
-		}
-
 		// Check if Pronamic Pay gateway.
-		if ( ! \method_exists( $payment_gateway, 'get_wp_payment_method' ) ) {
+		if ( ! $payment_gateway instanceof Gateway ) {
 			return $payment_method_title;
 		}
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -91,6 +91,7 @@ class Extension extends AbstractPluginIntegration {
 		add_filter( 'woocommerce_thankyou_order_received_text', self::woocommerce_thankyou_order_received_text( ... ), 20, 2 );
 
 		\add_filter( 'woocommerce_order_get_payment_method_title', self::order_payment_method_title( ... ), 10, 2 );
+		\add_filter( 'woocommerce_subscription_payment_method_to_display', self::subscription_payment_method_to_display( ... ), 10, 3 );
 
 		\add_action( 'before_woocommerce_pay', $this->maybe_add_failure_reason_notice( ... ) );
 
@@ -327,6 +328,42 @@ class Extension extends AbstractPluginIntegration {
 			PaymentMethods::IDEAL, PaymentMethods::BANCONTACT => PaymentMethods::get_name( PaymentMethods::DIRECT_DEBIT ),
 			default => $payment_method_title,
 		};
+	}
+
+	/**
+	 * Filter WooCommerce subscription order payment method title.
+	 *
+	 * @param string    $payment_method_title Payment method title.
+	 * @param \WC_Order $order                WooCommerce order.
+	 * @param string    $context              Context.
+	 *
+	 * @return string
+	 */
+	public static function subscription_payment_method_to_display( $payment_method_title, $order, $context ) {
+		if ( 'customer' !== $context ) {
+			return $payment_method_title;
+		}
+
+		$payment_gateway = \wc_get_payment_gateway_by_order( $order );
+
+		if ( false === $payment_gateway ) {
+			return $payment_method_title;
+		}
+
+		// Check if Pronamic Pay gateway.
+		if ( ! \method_exists( $payment_gateway, 'get_wp_payment_method' ) ) {
+			return $payment_method_title;
+		}
+
+		$payment_method = $payment_gateway->get_wp_payment_method();
+
+		if ( ! \in_array( $payment_method, [ PaymentMethods::IDEAL, PaymentMethods::BANCONTACT ], true ) ) {
+			return $payment_method_title;
+		}
+
+		$payment_method_title = PaymentMethods::get_name( PaymentMethods::DIRECT_DEBIT );
+
+		return $payment_method_title;
 	}
 
 	/**

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -319,10 +319,15 @@ class Extension extends AbstractPluginIntegration {
 			return $payment_method_title;
 		}
 
-		return match ( $payment_gateway->get_wp_payment_method() ) {
-			PaymentMethods::IDEAL, PaymentMethods::BANCONTACT => PaymentMethods::get_name( PaymentMethods::DIRECT_DEBIT ),
-			default => $payment_method_title,
-		};
+		$payment_method = $payment_gateway->get_wp_payment_method();
+
+		if ( ! \in_array( $payment_method, [ PaymentMethods::IDEAL, PaymentMethods::BANCONTACT ], true ) ) {
+			return $payment_method_title;
+		}
+
+		$payment_method_title = PaymentMethods::get_name( PaymentMethods::DIRECT_DEBIT );
+
+		return $payment_method_title;
 	}
 
 	/**
@@ -341,7 +346,6 @@ class Extension extends AbstractPluginIntegration {
 
 		$payment_gateway = \wc_get_payment_gateway_by_order( $order );
 
-		// Check if Pronamic Pay gateway.
 		if ( ! $payment_gateway instanceof Gateway ) {
 			return $payment_method_title;
 		}


### PR DESCRIPTION
Fix https://github.com/pronamic/pronamic-pay/issues/126.

With this PR:
- payment method title "Direct Debit" for renewal orders using iDEAL or Bancontact (email, orders in account pages — note that pending orders, for which customers can pay manually from their account, still show the original payment method title as method being used for the "Pay" action)
- payment method title "Direct Debit" for subscriptions on customer account pages for subscriptions using iDEAL or Bancontact