### PR TITLE
Fixed error display during WooCommerce Checkout.

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -582,11 +582,8 @@ class Gateway extends WC_Payment_Gateway {
 		try {
 			$payment = Plugin::start_payment( $payment );
 		} catch ( \Exception $exception ) {
-			if ( empty( $exception->getMessage() ) ) {
-				WooCommerce::add_notice( Plugin::get_default_error_message(), 'error' );
-			} else {
-				WooCommerce::add_notice( $exception->getMessage(), 'error' );
-			}
+			$message = $exception->getMessage() ?: Plugin::get_default_error_message();
+			WooCommerce::add_notice( $message, 'error' );
 
 			return [
 				'result' => 'failure',

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -582,14 +582,15 @@ class Gateway extends WC_Payment_Gateway {
 		try {
 			$payment = Plugin::start_payment( $payment );
 		} catch ( \Exception $exception ) {
-			WooCommerce::add_notice( Plugin::get_default_error_message(), 'error' );
+			if ( empty( $exception->getMessage() ) ) {
+				WooCommerce::add_notice( Plugin::get_default_error_message(), 'error' );
+			} else {
+				WooCommerce::add_notice( $exception->getMessage(), 'error' );
+			}
 
-			/**
-			 * We will rethrow the exception so WooCommerce can also handle the exception.
-			 *
-			 * @link https://github.com/woocommerce/woocommerce/blob/3.7.1/includes/class-wc-checkout.php#L1129-L1131
-			 */
-			throw $exception;
+			return [
+				'result' => 'failure',
+			];
 		}
 
 		$this->store_payment_details( $order, $payment );


### PR DESCRIPTION
As per the new documentation of WooCommerce, 'result' => 'failure' needs to be returned in case of error. If throwing $exception, user will not be able to attempt payment again.

https://developer.woocommerce.com/docs/features/payments/payment-gateway-api/#process_payment-order_id-