### PR TITLE
Allow woocommerce/action-scheduler ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
 		"automattic/jetpack-autoloader": "^3.0 || ^4.0 || ^5.0",
 		"pronamic/wp-html": "^2.2",
 		"pronamic/wp-number": "^1.4",
-		"woocommerce/action-scheduler": "^3.9",
+		"woocommerce/action-scheduler": "^3.9 || ^4.0",
 		"wp-pay/core": "^4.28"
 	},
 	"require-dev": {
@@ -105,7 +105,7 @@
 		"pronamic/woocommerce-subscriptions": "^7.6",
 		"pronamic/wp-coding-standards": "^2.2",
 		"rector/rector": "^1.2",
-		"roots/wordpress": "^6.4",
+		"roots/wordpress": "^6.8",
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"vimeo/psalm": "^0.3.14",
 		"wp-cli/wp-cli": "^2.10",

--- a/pronamic-pay-woocommerce.php
+++ b/pronamic-pay-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Extend the Pronamic Pay plugin with WooCommerce support to receive payments through a variety of payment providers.
  *
  * Version: 4.14.2
- * Requires at least: 5.9
+ * Requires at least: 6.8
  * Requires PHP: 7.4
  *
  * Author: Pronamic


### PR DESCRIPTION
Update the `woocommerce/action-scheduler` Composer constraint to also allow the new 4.0 branch using an OR operator.